### PR TITLE
Refine implementations needed for EF6 and filter out file-based program projects

### DIFF
--- a/EnvDTE.Client/Impl/ProjectModelImpl/ProjectItemImplementation.cs
+++ b/EnvDTE.Client/Impl/ProjectModelImpl/ProjectItemImplementation.cs
@@ -60,7 +60,8 @@ namespace JetBrains.EnvDTE.Client.Impl.ProjectModelImpl
         {
             get
             {
-                _properties ??= new ProjectItemPropertiesImplementation(dte, this, projectItemModel);
+                _properties ??= new ProjectItemPropertiesImplementation(dte, this, projectItemModel,
+                    dte.DteProtocolModel.ProjectItem_get_Kind.Sync(new(projectItemModel)));
                 return _properties;
             }
         }

--- a/EnvDTE.Client/Impl/ProjectModelImpl/PropertyImpl/ProjectItemPropertiesImplementation.cs
+++ b/EnvDTE.Client/Impl/ProjectModelImpl/PropertyImpl/ProjectItemPropertiesImplementation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using EnvDTE;
 using JetBrains.Annotations;
@@ -12,14 +13,17 @@ namespace JetBrains.EnvDTE.Client.Impl.ProjectModelImpl.PropertyImpl;
 public class ProjectItemPropertiesImplementation(
     [NotNull] DteImplementation dte,
     [NotNull] object parent,
-    [NotNull] ProjectItemModel projectItemModel)
+    [NotNull] ProjectItemModel projectItemModel,
+    ProjectItemKindModel itemKind)
     : PropertiesImplementation(dte, parent)
 {
-    public override int Count => VisualStudioProperties.ProjectItemPropertiesMap.Count;
+    private IReadOnlyDictionary<string, StringPropertyInfo> PropertyMap => VisualStudioProperties.GetItemKindSpecificMap(itemKind);
+
+    public override int Count => PropertyMap.Count;
 
     public override Property Item(object index)
     {
-        var map = VisualStudioProperties.ProjectItemPropertiesMap;
+        var map = PropertyMap;
 
         if (index is int intIndex)
         {
@@ -28,16 +32,13 @@ public class ProjectItemPropertiesImplementation(
             return new ProjectItemPropertyImplementation(DteImplementation, this, projectItemModel, propertyInfoAtIndex);
         }
 
-        if (index is string stringIndex)
-        {
-            return map.TryGetValue(stringIndex, out var propertyInfoByName)
-                ? new ProjectItemPropertyImplementation(DteImplementation, this, projectItemModel, propertyInfoByName)
-                : new NullPropertyImplementation(DteImplementation, this, stringIndex);
-        }
+        if (index is string stringIndex && map.TryGetValue(stringIndex, out var propertyInfoByName))
+            return new ProjectItemPropertyImplementation(DteImplementation, this, projectItemModel, propertyInfoByName);
 
         throw new ArgumentException(nameof(index));
     }
 
-    public override IEnumerator GetEnumerator() => VisualStudioProperties.ProjectItemPropertiesMap.Values.Select(info =>
-        new ProjectItemPropertyImplementation(DteImplementation, this, projectItemModel, info)).GetEnumerator();
+    public override IEnumerator GetEnumerator() => PropertyMap.Values
+        .Select(info => new ProjectItemPropertyImplementation(DteImplementation, this, projectItemModel, info))
+        .GetEnumerator();
 }

--- a/EnvDTE.Client/Impl/ProjectModelImpl/PropertyImpl/PropertyInfo/VisualStudioProperties.ProjectItem.cs
+++ b/EnvDTE.Client/Impl/ProjectModelImpl/PropertyImpl/PropertyInfo/VisualStudioProperties.ProjectItem.cs
@@ -1,13 +1,38 @@
 ﻿using System.Collections.Generic;
+using JetBrains.Rider.Model;
 
 namespace JetBrains.EnvDTE.Client.Impl.ProjectModelImpl.PropertyImpl.PropertyInfo;
 
+// TODO: Implement these fully - Right now they MsBuild metadata properties are not supported
 internal static partial class VisualStudioProperties
 {
-    // TODO: Implement this fully
-    internal static readonly IReadOnlyDictionary<string, StringPropertyInfo> ProjectItemPropertiesMap =
+    // Some common properties for files - mainly related to the file system
+    internal static readonly IReadOnlyDictionary<string, StringPropertyInfo> CommonProjectItemFilePropertiesMap =
         new Dictionary<string, StringPropertyInfo>
         {
+            ["DateCreated"] = new("DateCreated", "DateCreated", true),
+            ["DateModified"] = new("DateModified", "DateModified", true),
+            ["Extension"] = new("Extension", "Extension", true),
+            ["FileName"] = new("FileName", "FileName", true),
+            ["Filesize"] = new("Filesize", "FileSize", true),
+            ["LocalPath"] = new("LocalPath", "LocalPath", true),
             ["FullPath"] = new("FullPath", "FullPath", true)
+        };
+
+    // Some common properties for folders - mainly related to the file system
+    internal static readonly IReadOnlyDictionary<string, StringPropertyInfo> CommonProjectItemFolderPropertiesMap =
+        new Dictionary<string, StringPropertyInfo>
+        {
+            ["FileName"] = new("FileName", "FileName", true),
+            ["LocalPath"] = new("LocalPath", "LocalPath", true),
+            ["FullPath"] = new("FullPath", "FullPath", true)
+        };
+
+    internal static IReadOnlyDictionary<string, StringPropertyInfo> GetItemKindSpecificMap(ProjectItemKindModel itemKind) =>
+        itemKind switch
+        {
+            ProjectItemKindModel.PhysicalFile => CommonProjectItemFilePropertiesMap,
+            ProjectItemKindModel.PhysicalFolder => CommonProjectItemFolderPropertiesMap,
+            _ => new Dictionary<string, StringPropertyInfo>()
         };
 }

--- a/EnvDTE.Host/Callback/Impl/ProjectModelImpl/ProjectCallbackProvider.cs
+++ b/EnvDTE.Host/Callback/Impl/ProjectModelImpl/ProjectCallbackProvider.cs
@@ -32,9 +32,7 @@ namespace JetBrains.EnvDTE.Host.Callback.Impl.ProjectModelImpl
                 lifetime.StartReadActionAsync(() =>
                     solution.InvokeUnderTransaction(cookie => cookie.Rename(project, req.NewName))));
 
-            // TODO: Use project extension
-            model.Project_get_FileName.SetWithProjectSync(host, (_, project) =>
-                project.IsWebProject() ? project.Location.FullPath : project.ProjectFileLocation.FullPath);
+            model.Project_get_FileName.SetWithProjectSync(host, (_, project) => project.GetProjectFullPath());
 
             model.Project_get_UniqueName.SetWithProjectSync(host, (_, project) => vsCompatibilityService.GetVSUniqueName(project));
 

--- a/EnvDTE.Host/Callback/Impl/ProjectModelImpl/ProjectItemCallbackProvider.cs
+++ b/EnvDTE.Host/Callback/Impl/ProjectModelImpl/ProjectItemCallbackProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using JetBrains.Application.Components;
 using JetBrains.Application.Parts;
 using JetBrains.Collections.Viewable;
@@ -27,6 +28,8 @@ namespace JetBrains.EnvDTE.Host.Callback.Impl.ProjectModelImpl
         ISimpleLazy<IProjectModelEditor> projectModelEditor)
         : IEnvDteCallbackProvider
     {
+        private const string DateTimeFormat = "MM/dd/yyyy HH:mm:ss";
+
         public void RegisterCallbacks(DteProtocolModel model, IScheduler scheduler)
         {
             model.ProjectItem_get_Name.SetWithProjectItemAsync(host, async (lifetime, _, projectItem) =>
@@ -82,18 +85,32 @@ namespace JetBrains.EnvDTE.Host.Callback.Impl.ProjectModelImpl
             {
                 var itemNames = await lifetime.StartReadActionAsync(() =>
                     GetFilteredProjectItems(projectItem).Select(item => item.Name).ToArray());
-                var index =  itemNames.IndexOf(req.Name, StringComparer.OrdinalIgnoreCase);
+                var index = itemNames.IndexOf(req.Name, StringComparer.OrdinalIgnoreCase);
                 return index == -1 ? null : index;
             });
 
-            // TODO: Implement fully
             model.ProjectItem_get_Property.SetWithProjectItemSync(host, (request, item) => request.Name switch
             {
+                "DateCreated" => (GetCachedFileSystemData(item)?.CreationTimeUtc ??
+                                  item.Location.ToNativeFileSystemPath().FileCreationTimeUtc).ToString(DateTimeFormat),
+                "DateModified" => (GetCachedFileSystemData(item)?.LastWriteTimeUtc ??
+                                   item.Location.ToNativeFileSystemPath().FileModificationTimeUtc).ToString(DateTimeFormat),
+                "Extension" => item.Location.ExtensionWithDot,
+                "FileName" => item.Location.Name,
+                "FileSize" => item.Location.ToNativeFileSystemPath().Info?.Length.ToString(),
+                "LocalPath" => item.Location.FullPath,
                 "FullPath" => item.Location.FullPath,
                 _ => null
             });
 
-            model.ProjectItem_set_Property.SetWithProjectItemSync(host, (request, item) => Unit.Instance);
+            model.ProjectItem_set_Property.SetWithProjectItemSync(host, (_, _) => Unit.Instance);
+        }
+
+        [CanBeNull]
+        private CachedFileSystemData GetCachedFileSystemData(IProjectItem projectItem)
+        {
+            if (projectItem is ProjectFileImpl projectFile) return projectFile.CachedFileSystemData;
+            return null;
         }
 
         private IEnumerable<IProjectItem> GetFilteredProjectItems(IProjectItem projectItem)

--- a/EnvDTE.Host/Callback/Impl/ProjectModelImpl/ProjectItemsCallbackProvider.cs
+++ b/EnvDTE.Host/Callback/Impl/ProjectModelImpl/ProjectItemsCallbackProvider.cs
@@ -1,16 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using JetBrains.Application.Components;
 using JetBrains.Application.Parts;
 using JetBrains.Collections.Viewable;
+using JetBrains.DataFlow;
 using JetBrains.DocumentManagers.Transactions;
 using JetBrains.DocumentManagers.Transactions.ProjectHostActions.Modifications;
 using JetBrains.EnvDTE.Host.Callback.Util;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
+using JetBrains.ProjectModel.ProjectImplementation.Structure;
 using JetBrains.RdBackend.Common.Features.ProjectModel;
+using JetBrains.RdBackend.Common.Features.ProjectModel.FileNesting;
 using JetBrains.RdBackend.Common.Features.ProjectModel.View;
 using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.Rider.Model;
@@ -19,58 +24,105 @@ using JetBrains.Util;
 namespace JetBrains.EnvDTE.Host.Callback.Impl.ProjectModelImpl;
 
 [SolutionComponent(Instantiation.DemandAnyThreadSafe)]
-public class ProjectItemsCallbackProvider(
-    ILogger logger,
-    ISolution solution,
-    ProjectModelViewHost host,
-    ISimpleLazy<IProjectModelEditor> projectModelEditor
-    ) : IEnvDteCallbackProvider
+public class ProjectItemsCallbackProvider : IEnvDteCallbackProvider
 {
+    private readonly StringSuffixTree<HashSet<string>> _customNestingRules;
+    [CanBeNull] private StringSuffixTree<HashSet<string>> _riderNestingRules;
+
+    private readonly ILogger _logger;
+    private readonly ISolution _solution;
+    private readonly ProjectModelViewHost _host;
+    private readonly ISimpleLazy<IProjectModelEditor> _projectModelEditor;
+
+    public ProjectItemsCallbackProvider(
+        Lifetime lifetime,
+        ILogger logger,
+        ISolution solution,
+        ProjectModelViewHost host,
+        ISimpleLazy<IProjectModelEditor> projectModelEditor,
+        FileNestingHost fileNestingHost)
+    {
+        _logger = logger;
+        _solution = solution;
+        _host = host;
+        _projectModelEditor = projectModelEditor;
+
+        // Even though we do have Rider's nesting rules, the default set of rules is missing a rule that puts 'resx' files under code files.
+        // This rule is really important for EF6, which generates resource files for migrations, and 'Update-Database' won't work
+        // unless that file is nested properly under the code file (has a 'DependentUpon' metadata set).
+        _customNestingRules = CreateNestingRules(
+            (".resx", ".cs"),
+            (".resx", ".vb"),
+            (".resx", ".fs")
+        );
+        fileNestingHost.Rules.Change.Advise_HasNew(lifetime, x => _riderNestingRules = x.New);
+    }
+
     public void RegisterCallbacks(DteProtocolModel model, IScheduler scheduler)
     {
-        model.ProjectItems_addFolder.SetWithProjectFolderAsync(host, AddFolderAsync);
-        model.ProjectItems_addFromFile.SetWithProjectFolderAsync(host, (lifetime, request, projectFolder) =>
+        model.ProjectItems_addFolder.SetWithProjectFolderAsync(_host, AddFolderAsync);
+        model.ProjectItems_addFromFile.SetWithProjectFolderAsync(_host, (lifetime, request, projectFolder) =>
             AddExistingItemAsync(lifetime, request, projectFolder));
-        model.ProjectItems_addFromDirectory.SetWithProjectFolderAsync(host, (lifetime, request, projectFolder) =>
+        model.ProjectItems_addFromDirectory.SetWithProjectFolderAsync(_host, (lifetime, request, projectFolder) =>
             AddExistingItemAsync(lifetime, request, projectFolder, copyBeforeAdd: true));
-        model.ProjectItems_addFromFileCopy.SetWithProjectFolderAsync(host, (lifetime, request, projectFolder) =>
+        model.ProjectItems_addFromFileCopy.SetWithProjectFolderAsync(_host, (lifetime, request, projectFolder) =>
             AddExistingItemAsync(lifetime, request, projectFolder, copyBeforeAdd: true));
     }
 
     private async Task<ProjectItemModel> AddFolderAsync(Lifetime lifetime, ProjectItems_addFolderRequest request,
         IProjectFolder parentFolder)
     {
-        logger.Trace($"Adding folder '{request.Name}' to '{parentFolder.Location}'");
+        _logger.Trace($"Adding folder '{request.Name}' to '{parentFolder.Location}'");
 
         var result = await lifetime.StartMainWrite(() =>
-            projectModelEditor.Value.AddFolder(parentFolder, request.Name));
+            _projectModelEditor.Value.AddFolder(parentFolder, request.Name));
 
         return result is null
             ? null
-            : new ProjectItemModel(host.GetIdByItem(result));
+            : new ProjectItemModel(_host.GetIdByItem(result));
     }
 
     [CanBeNull]
     private string GetDependsUponFileName(VirtualFileSystemPath filePath)
     {
         var fileName = filePath.Name;
-        var nameWithoutExt = filePath.NameWithoutExtension;
+        var parentPath = filePath.Parent;
 
-        foreach (var codeExt in new[] { ".cs", ".vb", ".fs" })
+        var result =
+            GetDependsUponFileNameBasedOnRules(_customNestingRules) ??
+            GetDependsUponFileNameBasedOnRules(_riderNestingRules);
+
+        _logger.Trace($"GetDependsUponFileName: {parentPath}, found: {result.QuoteIfNeeded()}");
+
+        return result;
+
+        string GetDependsUponFileNameBasedOnRules([CanBeNull] StringSuffixTree<HashSet<string>> nestingRules)
         {
-            string baseName;
-            if (fileName.EndsWith(".Designer" + codeExt, StringComparison.OrdinalIgnoreCase))
-                baseName = nameWithoutExt.Substring(0, nameWithoutExt.Length - ".Designer".Length);
-            else if (filePath.ExtensionNoDot.Equals("resx", StringComparison.OrdinalIgnoreCase))
-                baseName = nameWithoutExt;
-            else
-                continue;
+            var suffixData = nestingRules?.FindLongestSuffix(fileName);
+            if (suffixData is null) return null;
 
-            var codeFile = filePath.Parent / (baseName + codeExt);
-            if (codeFile.ExistsFile) return baseName + codeExt;
+            var baseName = fileName.Substring(0, fileName.Length - suffixData.Value.SuffixLength);
+            foreach (var parentSuffix in suffixData.Value.Data)
+            {
+                var dependsUponFiles = parentPath / (baseName + parentSuffix);
+
+                if (dependsUponFiles.ExistsFile)
+                    return dependsUponFiles.Name;
+            }
+
+            return null;
+        }
+    }
+
+    private StringSuffixTree<HashSet<string>> CreateNestingRules(params (string Suffix, string NestUnderSuffix)[] rules)
+    {
+        var result = new StringSuffixTree<HashSet<string>>();
+        foreach (var group in rules.GroupBy(x => x.Suffix))
+        {
+            result.Add(group.Key, group.Select(x => x.NestUnderSuffix).ToHashSet());
         }
 
-        return null;
+        return result;
     }
 
     private async Task<ProjectItemModel> AddExistingItemAsync(
@@ -91,7 +143,7 @@ public class ProjectItemsCallbackProvider(
         if (copyBeforeAdd)
         {
             var destinationPath = parentFolder.Location / sourcePath.Name;
-            logger.Trace($"Copying {sourcePath} to {destinationPath}");
+            _logger.Trace($"Copying {sourcePath} to {destinationPath}");
 
             try
             {
@@ -99,18 +151,18 @@ public class ProjectItemsCallbackProvider(
             }
             catch (Exception e)
             {
-                logger.Error(e, $"Failed to copy {sourcePath} to {destinationPath}");
+                _logger.Error(e, $"Failed to copy {sourcePath} to {destinationPath}");
                 throw new IOException("Failed to copy the item");
             }
 
             sourcePath = destinationPath;
         }
 
-        logger.Trace($"Adding existing item from '{sourcePath}' to '{parentFolder.Location}'");
+        _logger.Trace($"Adding existing item from '{sourcePath}' to '{parentFolder.Location}'");
 
         IProjectItem result = null;
         await lifetime.StartMainWrite(() =>
-            solution.InvokeUnderTransaction(cookie =>
+            _solution.InvokeUnderTransaction(cookie =>
             {
                 AddItemTaskAction action;
                 if (parentFolder.IsSolutionFolder())
@@ -120,11 +172,9 @@ public class ProjectItemsCallbackProvider(
                 else
                     action = new AddItemAsLinkTaskAction(lifetime, cookie, parentFolder, sourcePath);
 
-                // This is a hack needed because Rider doesn't set the necessary 'DependentUpon' metadata for resource and Designer files created under code files.
-                // EF6 generates the resource files next to migration files, and they have to be properly placed for 'Update-Database' to work.
-                // TODO: Figure out if there's any better way to handle this
+                // We are not using `IDependsUponProvider` because it requires an already existing `IProjectFile`
                 var dependsUponName = GetDependsUponFileName(sourcePath);
-                if (dependsUponName != null)
+                if (dependsUponName is not null)
                     action.Parameters.SetDependentUpon(dependsUponName);
 
                 result = action.Execute();
@@ -132,6 +182,6 @@ public class ProjectItemsCallbackProvider(
 
         return result is null
             ? null
-            : new ProjectItemModel(host.GetIdByItem(result));
+            : new ProjectItemModel(_host.GetIdByItem(result));
     }
 }

--- a/EnvDTE.Host/Callback/Impl/ProjectModelImpl/SolutionCallbackProvider.cs
+++ b/EnvDTE.Host/Callback/Impl/ProjectModelImpl/SolutionCallbackProvider.cs
@@ -258,7 +258,7 @@ namespace JetBrains.EnvDTE.Host.Callback.Impl.ProjectModelImpl
         // have a unique id. In the future it would be better to start using project guids instead, but since that complicates
         // the client side, I'm not going to do it now.
         private IEnumerable<IProject> GetFilteredProjects() => solution.GetTopLevelProjects()
-            .Where(p => p.IsProjectFromUserView() || p.IsSolutionFolder());
+            .Where(p => (p.IsProjectFromUserView() || p.IsSolutionFolder()) && !p.IsFileBasedProgramProject());
 
         private void ExecuteBuildRequest(SolutionBuilderRequest request, bool waitForBuild, Lifetime lifetime)
         {

--- a/EnvDTE.Host/Callback/Impl/ProjectModelImpl/SolutionCallbackProvider.cs
+++ b/EnvDTE.Host/Callback/Impl/ProjectModelImpl/SolutionCallbackProvider.cs
@@ -187,7 +187,6 @@ namespace JetBrains.EnvDTE.Host.Callback.Impl.ProjectModelImpl
                     SolutionBuilderRequestSilentMode.Default,
                     new SolutionBuilderRequestAdvancedSettings
                     {
-                        // TODO: This doesn't work for ReSharper build
                         InputProperties = [
                             new InputProperty(MSBuildProjectUtil.ConfigurationProperty, configuration.Configuration),
                             new InputProperty(MSBuildProjectUtil.PlatformProperty, configuration.Platform)
@@ -226,7 +225,7 @@ namespace JetBrains.EnvDTE.Host.Callback.Impl.ProjectModelImpl
 
             model.Solution_get_ConfigurationByName.SetWithSolutionMarkSync(solution, (name, solutionMark) =>
                 solutionMark.ConfigurationAndPlatformStore.ConfigurationsAndPlatforms
-                    .FirstOrDefault(cp => cp.Configuration.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault(cp => cp.Configuration.Equals(name))
                     ?.ToRdSolutionConfiguration());
         }
 

--- a/EnvDTE.Host/Callback/Util/SolutionExtensions.cs
+++ b/EnvDTE.Host/Callback/Util/SolutionExtensions.cs
@@ -100,20 +100,18 @@ public static class SolutionExtensions
         var solutionMark = solution.GetSolutionMark();
         if (solutionMark is null) return null;
 
+        var configurations = solutionMark.ConfigurationAndPlatformStore.ConfigurationsAndPlatforms;
         var parts = value.Split('|');
-        if (parts.Length == 1)
-            // If the platform is not specified, use the first configuration
-            return solutionMark.ConfigurationAndPlatformStore.ConfigurationsAndPlatforms
-                .FirstOrDefault(cp => cp.Configuration.Equals(parts[0], StringComparison.OrdinalIgnoreCase));
 
-        if (parts.Length == 2 && !string.IsNullOrWhiteSpace(parts[0]) && !string.IsNullOrWhiteSpace(parts[1]))
+        // NOTE: Configuration names in Rider are case-sensitive, but in VS they are not. We will follow Rider's behavior here
+        return parts.Length switch
         {
-            var config = new SolutionConfigurationAndPlatform(parts[0], parts[1]);
-            return solutionMark.ConfigurationAndPlatformStore.ConfigurationsAndPlatforms
-                .SingleOrDefault(cp => cp.Equals(config));
-        }
-
-        return null;
+            // If the platform is not specified, use the first configuration
+            1 => configurations.FirstOrDefault(cp => cp.Configuration.Equals(parts[0])),
+            2 when !string.IsNullOrWhiteSpace(parts[0]) && !string.IsNullOrWhiteSpace(parts[1])
+                => configurations.SingleOrDefault(cp => cp.Equals(new SolutionConfigurationAndPlatform(parts[0], parts[1]))),
+            _ => null
+        };
     }
 
     public static void SetActiveConfigurationAndPlatform([NotNull] this ISolution solution, [CanBeNull] string value)


### PR DESCRIPTION
This is a PR that builds on top of #43 . The code is cleaned up and improved in some cases:
- Improved handling of dependent files added through one of the `ProjectItems` methods. The new implementation follows the platform implementation by using nesting rules. Custom rules were defined for necessary fixes, but existing Rider rules are used as a fallback.
- Improved parsing of configurations in `BuildProject` so that Rider's case sensitive configuration name behavior is respected. Custom configurations are still not supported for incremental builds, but that is not responsibility of EnvDTE and will be fixed separately in Rider.
- Improved support for project file properties. For now, only limited set of properties is supported. These are file system related properties that are most commonly used. I decided not to go for full implementation because it would have taken me too much time to figure out the best way to extract MsBuild metadata, which is needed for the rest of them, efficiently. Not to mention that in VS different files, located in different projects, have different set of properties which can come from many different places, and figuring all of that out takes a lot of time.
- Ignore projects coming from the file-based programs, so now the `Projects` collection inside of `Solution` doesn't return them.  