### PR TITLE
Fix the file access race during build

### DIFF
--- a/EnvDTE.Interfaces/EnvDTE.Interfaces.csproj
+++ b/EnvDTE.Interfaces/EnvDTE.Interfaces.csproj
@@ -11,6 +11,6 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-      <Exec Command="$(DotNetCliPath) run --project EnvDTE.Processor -- $(TargetPath)" WorkingDirectory="$(RepositoryRootPath)" />
+      <Exec Command="$(DotNetCliPath) run --no-build --project EnvDTE.Processor -- $(TargetPath)" WorkingDirectory="$(RepositoryRootPath)" />
     </Target>
 </Project>


### PR DESCRIPTION
This was happening because in the post build event for `EnvDTE.Interfaces` we used to rebuild `EnvDTE.Processor` before running it. Since the interfaces project targets multiple frameworks, this would run for all of them, often concurrently, leading to file access race. Since we already pre build the processor in the build script, and since it has no TFM-specific variations, we can just use that and not rebuild it again.